### PR TITLE
Autopopulate required fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config/
 *.sublime-project
+Salesforce-Test-Factory.sublime-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config/
+*.sublime-project

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Main features are:
 - Differentiate insertion and creation methods. If the method name start with "create", then it only creates the record without inserting it into the database. If the method starts with "insert", the record is created and inserted in the database.
 
 Fields will get values following this order:
+
 1- If you input values when calling the method, these values are prioritized and overrite everthing else.
+
 2- If you don't input values, then the TestFactory will look for the defaults and use them (Default as per the original repo logic). 
+
 3- If there is no default, then the TestFactory will automatically populates the fields.
 
 In short, auto-population is used as last resort if the developer doesn't input data and there is no default.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@ Salesforce-Test-Factory
 =======================
 
 SObject factory that can be used in unit tests to create test data.
+This is a fork of dhoechst repo: https://github.com/dhoechst/Salesforce-Test-Factory.
+It keeps the same core functionality and exntends it.
+
+Main features are:
+- Auto-generatation of test data for required and unique fields. Required fields automatically get populated with random values if you set the param autoSetRequiredFields to true. You don't have to worry about unique fields either, they are incremented in bulk scenarios.
+- RunAs(user) to test different scenarios for different users/profiles.
+- Differentiate insertion and creation methods. If the method name start with "create", then it only creates the record without inserting it into the database. If the method starts with "insert", the record is created and inserted in the database.
+
+Fields will get values following this order:
+1- If you input values when calling the method, these values are prioritized and overrite everthing else.
+2- If you don't input values, then the TestFactory will look for the defaults and use them (Default as per the original repo logic). 
+3- If there is no default, then the TestFactory will automatically populates the fields.
+
+In short, auto-population is used as last resort if the developer doesn't input data and there is no default.
+
+All field types are supported by the auto-generation feature, except: Base64, EncryptedString, Time, Reference (lookup and master-detail).
+
+Please keep in mind, that knowing the data and entering it manually is a better practice than generating it automatically. Auto-generation is made to save time on some specific scenarios. Don't rely 100% on auto-generation, as they can fail due to custom business validation rules and other customizations that might restrict input values.
+
+You can extend this framework easily by creating other defaults or other methods for example, and this will allow you to support your custom business rules.
 
 <a href="https://githubsfdeploy.herokuapp.com/?owner=dhoechst&repo=Salesforce-Test-Factory">
   <img alt="Deploy to Salesforce"
@@ -10,20 +30,23 @@ SObject factory that can be used in unit tests to create test data.
 
 Usage:
 
-    // The TestFactory will pre-fill all the fields we typically need
-    Account a = (Account)TestFactory.createSObject(new Account());
+    // Single account creation, the TestFactory will use the defaults. Autopopulate is set to false here, so no auto test data generation is going to happen
+    Account a = (Account)TestFactory.createSObject(new Account(), false);
+    insert a;
+
+    // Single account creation, the TestFactory will use the default and then generates data for all required fields if necessary
+    Account a = (Account)TestFactory.createSObject(new Account(), true);
     insert a;
     
-    // You can also set values to be used. Any values set in the constructor will override the defaults
-    Opportunity o = (Opportunity)TestFactory.createSObject(new Opportunity(AccountId = a.Id));
+    // You can  set values to be used. Any values set in the constructor will override the defaults
+    Opportunity o = (Opportunity)TestFactory.createSObject(new Opportunity(AccountId = a.Id), true);
     
     // You can also specify a specific set of overrides for different scenarios
-    Account a = (Account)TestFactory.createSObject(new Account(), 'TestFactory.AccountDefaults');
-    
-    // Finally, get a bunch of records for testing bulk
-    Account[] aList = (Account[])TestFactory.createSObjectList(new Account(), 200);
+    Account a = (Account)TestFactory.createSObject(new Account(), 'TestFactory.AccountDefaults', true);
 
-    // You can optionally insert records as created like this:
-    // Note the final parameter of true.
-    Account a = (Account) TestFactory.createSObject(new Account(), true);
-	Contact c = (Contact) TestFactory.createSObject(new Contact(AccountID = a.Id), true);
+    // You can insert directly into the DB using an insert method, and set the running user
+    User myUser = [SELECT Id FROM User WHERE Name = 'Riadh' LIMIT 1];
+    Account a = (Account)TestFactory.insertSObject(new Account(), true, myUser);
+    
+    // Get a bunch of records for testing bulk - autopopulation is set to true here, so unique and required fields are taking care of
+    Account[] aList = (Account[])TestFactory.createSObjectList(new Account(), 200, true);

--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -15,14 +15,14 @@ public class TestFactory {
 		if (Type.forName(defaultClassName) != null) {
 			sObj = createSObject(sObj, defaultClassName, autoSetRequiredFields);
 		}
+		else {
+			sObj = createSObject(sObj, null, autoSetRequiredFields);
+		}
 		return sObj;
 	}
 
 	public static SObject insertSObject(SObject sObj, Boolean autoSetRequiredFields) {
 		SObject retObject = createSObject(sObj, autoSetRequiredFields);
-		if (autoSetRequiredFields) {
-			addRequiredFields(retObject);
-		}
 		insert retObject;
 		return retObject;
 	}
@@ -37,14 +37,15 @@ public class TestFactory {
 	}
 
 	public static SObject createSObject(SObject sObj, String defaultClassName, Boolean autoSetRequiredFields) {
-		// Create an instance of the defaults class so we can get the Map of field defaults
-		Type t = Type.forName(defaultClassName);
-		if (t == null) {
-			Throw new TestFactoryException('Invalid defaults class.');
+		if (defaultClassName != null) {
+			// Create an instance of the defaults class so we can get the Map of field defaults
+			Type t = Type.forName(defaultClassName);
+			if (t == null) {
+				Throw new TestFactoryException('Invalid defaults class.');
+			}
+			FieldDefaults defaults = (FieldDefaults)t.newInstance();
+			addFieldDefaults(sObj, defaults.getFieldDefaults());
 		}
-		FieldDefaults defaults = (FieldDefaults)t.newInstance();
-		addFieldDefaults(sObj, defaults.getFieldDefaults());
-
 		if (autoSetRequiredFields) {
 			addRequiredFields(sObj);
 		}
@@ -256,7 +257,9 @@ public class TestFactory {
 					List<String> lst_picklistVals = getPicklistVals(objectName, fieldDesc.getName());
 					randomFieldVal = String.join(lst_picklistVals, ';');
 				}
-
+				else { // non supporeted field type
+					continue;
+				}
 				// Finally, populate the record with the required fields
 				sObj.put(fieldToken, randomFieldVal);
 			}	

--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -1,8 +1,10 @@
-// Insertion mode should be in a dedicated function and not a param 
 @isTest
 public class TestFactory {
 
-	public static List<Schema.DescribeFieldResult> requiredFields;
+	// Cached metadata structure
+	public static Map<String, List<Schema.DescribeFieldResult>> requiredFieldsMap = new Map<String, List<Schema.DescribeFieldResult>>();
+	public static Map<String, Map<String, Schema.SObjectField>> sobjectToFieldsMap = new Map<String, Map<String, Schema.SObjectField>>();
+	public static Map<String, List<String>> uniqueCustomFields = new Map<String, List<String>>();
 
 	public static SObject createSObject(SObject sObj, Boolean autoSetRequiredFields) {
 		// Check what type of object we are creating and add any defaults that are needed.
@@ -16,14 +18,12 @@ public class TestFactory {
 		return sObj;
 	}
 
-	public static SObject createSObject(SObject sObj, Boolean doInsert, Boolean autoSetRequiredFields) {
+	public static SObject insertSObject(SObject sObj, Boolean autoSetRequiredFields) {
 		SObject retObject = createSObject(sObj, autoSetRequiredFields);
 		if (autoSetRequiredFields) {
 			addRequiredFields(retObject);
 		}
-		if (doInsert) {
-			insert retObject;
-		}
+		insert retObject;
 		return retObject;
 	}
 
@@ -42,14 +42,12 @@ public class TestFactory {
 		return sObj;
 	}
 
-	public static SObject createSObject(SObject sObj, String defaultClassName, Boolean doInsert, Boolean autoSetRequiredFields) {
+	public static SObject insertSObject(SObject sObj, String defaultClassName, Boolean autoSetRequiredFields) {
 		SObject retObject = createSObject(sObj, defaultClassName, autoSetRequiredFields);
 		if (autoSetRequiredFields) {
 			addRequiredFields(retObject);
 		}
-		if (doInsert) {
-			insert retObject;
-		}
+		insert retObject;
 		return retObject;
 	}
 
@@ -57,27 +55,24 @@ public class TestFactory {
 		return createSObjectList(sObj, numberOfObjects, (String)null, autoSetRequiredFields);
 	}
 
-	public static SObject[] createSObjectList(SObject sObj, Integer numberOfObjects, Boolean doInsert, Boolean autoSetRequiredFields) {
+	public static SObject[] insertSObjectList(SObject sObj, Integer numberOfObjects, Boolean autoSetRequiredFields) {
 		SObject[] retList = createSObjectList(sObj, numberOfObjects, (String)null, autoSetRequiredFields);
-		if (doInsert) {
-			insert retList;
-		}
+		insert retList;
 		return retList;
 	}
 
-	public static SObject[] createSObjectList(SObject sObj, Integer numberOfObjects, String defaultClassName, Boolean doInsert, Boolean autoSetRequiredFields) {
+	public static SObject[] insertSObjectList(SObject sObj, Integer numberOfObjects, String defaultClassName, Boolean autoSetRequiredFields) {
 		SObject[] retList = createSObjectList(sObj, numberOfObjects, defaultClassName, autoSetRequiredFields);
-		if (doInsert) {
-			insert retList;
-		}
+		insert retList;
 		return retList;
 	}
 
 	public static SObject[] createSObjectList(Sobject sObj, Integer numberOfObjects, String defaultClassName, Boolean autoSetRequiredFields) {
+		String objectName = String.valueOf(sObj.getSObjectType());
 		SObject[] sObjs = new SObject[] {};
 		SObject newObj;
 
-		// Get one copy of the object
+		// Get one single copy of the object
 		if (defaultClassName != null) {
 			newObj = createSObject(sObj, defaultClassName, autoSetRequiredFields);
 		} 
@@ -85,16 +80,27 @@ public class TestFactory {
 			newObj = createSObject(sObj, autoSetRequiredFields);
 		}
 
+		if (uniqueCustomFields == null || !uniqueCustomFields.containsKey(objectName)) {
+			uniqueCustomFields.put(objectName, getUniqueCustomFields(objectName));
+		}
+
+		List<String> lst_uniqueFields = new List<String>();
 		// Get the name field for the object
 		String nameField = nameFieldMap.get(String.valueOf(sObj.getSObjectType()));
 		if (nameField == null) {
 			nameField = 'Name';
 		}
+		lst_uniqueFields.add(nameField);
 
-		// Clone the object the number of times requested. Increment the name field so each record is unique
+		// Get other unique custom fields for the object
+		lst_uniqueFields.addAll(uniqueCustomFields.get(objectName));
+
+		// Clone the object the number of times requested. Increment the name field + unique fields so each record is unique
 		for (Integer i = 0; i < numberOfObjects; i++) {
 			SObject clonedSObj = newObj.clone(false, true);
-			clonedSObj.put(nameField, (String)clonedSObj.get(nameField) + ' ' + i);
+			for (String uniqueField : lst_uniqueFields) {
+				clonedSObj.put(uniqueField, (String)clonedSObj.get(uniqueField) + '' + i);
+			}
 			sObjs.add(clonedSObj);
 		}
 		return sObjs;
@@ -162,20 +168,23 @@ public class TestFactory {
 	}
 
 	/**
-	 * The method automatically setups random values for required custom fields for the given object
-	 * But only the fields that were not already populated
-	 * As a first step, only the following types are supported: 'STRING', 'TEXTAREA', 'EMAIL', 'URL'
+	 * The method automatically setups random values for required custom fields for the given sobject.
+	 * But only the fields that were not already populated get a random value.
+	 * For now, only the following types are supported: 'STRING', 'TEXTAREA', 'EMAIL', 'URL'
 	 * More to be supported in the future: base64, currency, Date, Datetime, Double, Integer, Multipicklist, Picklist, percent
 	 * @param  sObj                    sobject token
 	 * @return                         generic sobject for testing purposes, with custom required fields randomly populated
 	 */
 	public static void addRequiredFields(SObject sObj) {
+		String objectName = String.valueOf(sObj.getSObjectType());
 		Map<String, Object> map_populatedFields = sObj.getPopulatedFieldsAsMap();
-		if (requiredFields == null) {
-			requiredFields = getRequiredCustomFields(sObj);
+
+		if (requiredFieldsMap == null || !requiredFieldsMap.containsKey(objectName)) {
+			requiredFieldsMap.put(objectName, getRequiredCustomFields(objectName));
 		}
 
-		for (Schema.DescribeFieldResult fieldDesc : requiredFields) {
+		List<Schema.DescribeFieldResult> lst_requiredFields = requiredFieldsMap.get(objectName);
+		for (Schema.DescribeFieldResult fieldDesc : lst_requiredFields) {
 			Schema.SObjectField fieldToken = fieldDesc.getSObjectField();
 			String currentType = fieldDesc.getType().name().toUpperCase();
 
@@ -216,26 +225,42 @@ public class TestFactory {
         return randomStr; 
     }
 
-    /**
-     * Given a sobject, the method provides the list of required custom fields except formulas, auto-number
-     * and field with already a default value defined
-     * @param  sObj sobject token
-     * @return      List<Schema.DescribeFieldResult> of required custom fields
-     */
-    public static List<Schema.DescribeFieldResult> getRequiredCustomFields(SObject sObj) {
-    	String objectName = String.valueOf(sObj.getSObjectType());
+    public static List<Schema.DescribeFieldResult> getRequiredCustomFields(String objectName) {
 		List<Schema.DescribeFieldResult> lst_requiredFields = new List<Schema.DescribeFieldResult>();
-		List<Schema.SObjectField> lst_fields = Schema.getGlobalDescribe().get(objectName).getDescribe().fields.getMap().values();
 		
+		if (!sobjectToFieldsMap.containsKey(objectName)) {
+			sobjectToFieldsMap.put(objectName, Schema.getGlobalDescribe().get(objectName).getDescribe().fields.getMap());
+		}
+
+		List<Schema.SObjectField> lst_fields = sobjectToFieldsMap.get(objectName).values();
 		for(Schema.SObjectField field : lst_fields) { 
 			Schema.DescribeFieldResult fieldDesc = field.getDescribe();
-			if (!fieldDesc.isNillable() && !fieldDesc.isAutoNumber() && !fieldDesc.isCalculated() 
-				&& !fieldDesc.isDefaultedOnCreate() && fieldDesc.isCustom()) 
+			if ( (!fieldDesc.isAutoNumber() && !fieldDesc.isCalculated() && fieldDesc.isCustom()) && 
+				 (!fieldDesc.isNillable() || fieldDesc.isUnique()) 
+			)
 			{
 				lst_requiredFields.add(fieldDesc);
 			}
 		}
 		return lst_requiredFields;	
+    }
+
+    public static List<String> getUniqueCustomFields(String objectName) {
+		List<String> lst_uniqueFields = new List<String>();
+
+		if (!sobjectToFieldsMap.containsKey(objectName)) {
+			sobjectToFieldsMap.put(objectName, Schema.getGlobalDescribe().get(objectName).getDescribe().fields.getMap());
+		}
+		
+		Map<String, Schema.SObjectField> map_fields = sobjectToFieldsMap.get(objectName);
+		Set<String> set_fieldNames = map_fields.keySet();
+		for(String fieldName : set_fieldNames) { 
+			Schema.DescribeFieldResult fieldDesc = map_fields.get(fieldName).getDescribe();
+			if (fieldDesc.isUnique() && !fieldDesc.isAutoNumber() && fieldDesc.isCustom()) {
+				lst_uniqueFields.add(fieldName);
+			}
+		}
+		return lst_uniqueFields;	
     }
 
 }

--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -1,29 +1,33 @@
+// Insertion mode should be in a dedicated function and not a param 
 @isTest
 public class TestFactory {
 
 	public static List<Schema.DescribeFieldResult> requiredFields;
 
-	public static SObject createSObject(SObject sObj) {
+	public static SObject createSObject(SObject sObj, Boolean autoSetRequiredFields) {
 		// Check what type of object we are creating and add any defaults that are needed.
 		String objectName = String.valueOf(sObj.getSObjectType());
 		// Construct the default values class. Salesforce doesn't allow '__' in class names
 		String defaultClassName = 'TestFactory.' + objectName.replaceAll('__(c|C)$|__', '') + 'Defaults';
 		// If there is a class that exists for the default values, then use them
 		if (Type.forName(defaultClassName) != null) {
-			sObj = createSObject(sObj, defaultClassName);
+			sObj = createSObject(sObj, defaultClassName, autoSetRequiredFields);
 		}
 		return sObj;
 	}
 
-	public static SObject createSObject(SObject sObj, Boolean doInsert) {
-		SObject retObject = createSObject(sObj);
+	public static SObject createSObject(SObject sObj, Boolean doInsert, Boolean autoSetRequiredFields) {
+		SObject retObject = createSObject(sObj, autoSetRequiredFields);
+		if (autoSetRequiredFields) {
+			addRequiredFields(retObject);
+		}
 		if (doInsert) {
 			insert retObject;
 		}
 		return retObject;
 	}
 
-	public static SObject createSObject(SObject sObj, String defaultClassName) {
+	public static SObject createSObject(SObject sObj, String defaultClassName, Boolean autoSetRequiredFields) {
 		// Create an instance of the defaults class so we can get the Map of field defaults
 		Type t = Type.forName(defaultClassName);
 		if (t == null) {
@@ -31,89 +35,54 @@ public class TestFactory {
 		}
 		FieldDefaults defaults = (FieldDefaults)t.newInstance();
 		addFieldDefaults(sObj, defaults.getFieldDefaults());
+
+		if (autoSetRequiredFields) {
+			addRequiredFields(sObj);
+		}
 		return sObj;
 	}
 
-	public static SObject createSObject(SObject sObj, String defaultClassName, Boolean doInsert) {
-		SObject retObject = createSObject(sObj, defaultClassName);
+	public static SObject createSObject(SObject sObj, String defaultClassName, Boolean doInsert, Boolean autoSetRequiredFields) {
+		SObject retObject = createSObject(sObj, defaultClassName, autoSetRequiredFields);
+		if (autoSetRequiredFields) {
+			addRequiredFields(retObject);
+		}
 		if (doInsert) {
 			insert retObject;
 		}
 		return retObject;
 	}
 
-	 /**
-	 * The method automatically setups random values for required custom fields for the given object
-	 * But only if the user didn't input values or default value doesn't exist.
-	 * As a first step, only these types are supported: 'STRING', 'TEXTAREA', 'EMAIL', 'URL'
-	 * More to be supported in the future: base64, currency, Date, Datetime, Double, Integer, Multipicklist, Picklist, percent
-	 * @param  sObj                    sobject token
-	 * @return                         generic sobject for testing purposes, with custom required fields randomly populated
-	 */
-	public static SObject createSObjectRequired(SObject sObj) {
-		SObject retObject = createSObject(sObj);
-
-		Map<String, Object> map_populatedFields = retObject.getPopulatedFieldsAsMap();
-		if (requiredFields == null) {
-			requiredFields = getRequiredCustomFields(retObject);
-		}
-
-		for (Schema.DescribeFieldResult fieldDesc : requiredFields) {
-			Schema.SObjectField fieldToken = fieldDesc.getSObjectField();
-			String currentType = fieldDesc.getType().name().toUpperCase();
-
-			// If the required custom field is already populated, continue
-			if (!map_populatedFields.containsKey(String.valueOf(fieldToken))) {
-				Object randomFieldVal;
-				// If current type is String
-				if (currentType == 'STRING' || currentType == 'TEXTAREA') {
-					Integer fieldLength = fieldDesc.getLength() > 20 ? 20 : fieldDesc.getLength();
-					randomFieldVal = getRandomStr(fieldLength);
-				}
-				// If current type is email
-				else if (currentType == 'EMAIL') {
-					randomFieldVal = getRandomStr(10) + '@' + getRandomStr(7) + '.com';
-				}
-				else if (currentType == 'URL') {
-					randomFieldVal = 'http://' + getRandomStr(10) + '.com';
-				}
-				// Finally, populate the record with the required fields
-				retObject.put(fieldToken, randomFieldVal);
-			}	
-		}
-
-		return retObject;
+	public static SObject[] createSObjectList(Sobject sObj, Integer numberOfObjects, Boolean autoSetRequiredFields) {
+		return createSObjectList(sObj, numberOfObjects, (String)null, autoSetRequiredFields);
 	}
 
-	public static SObject[] createSObjectList(Sobject sObj, Integer numberOfObjects) {
-		return createSObjectList(sObj, numberOfObjects, (String)null);
-	}
-
-	public static SObject[] createSObjectList(SObject sObj, Integer numberOfObjects, Boolean doInsert) {
-		SObject[] retList = createSObjectList(sObj, numberOfObjects, (String)null);
+	public static SObject[] createSObjectList(SObject sObj, Integer numberOfObjects, Boolean doInsert, Boolean autoSetRequiredFields) {
+		SObject[] retList = createSObjectList(sObj, numberOfObjects, (String)null, autoSetRequiredFields);
 		if (doInsert) {
 			insert retList;
 		}
 		return retList;
 	}
 
-	public static SObject[] createSObjectList(SObject sObj, Integer numberOfObjects, String defaultClassName, Boolean doInsert) {
-		SObject[] retList = createSObjectList(sObj, numberOfObjects, defaultClassName);
+	public static SObject[] createSObjectList(SObject sObj, Integer numberOfObjects, String defaultClassName, Boolean doInsert, Boolean autoSetRequiredFields) {
+		SObject[] retList = createSObjectList(sObj, numberOfObjects, defaultClassName, autoSetRequiredFields);
 		if (doInsert) {
 			insert retList;
 		}
 		return retList;
 	}
 
-	public static SObject[] createSObjectList(Sobject sObj, Integer numberOfObjects, String defaultClassName) {
+	public static SObject[] createSObjectList(Sobject sObj, Integer numberOfObjects, String defaultClassName, Boolean autoSetRequiredFields) {
 		SObject[] sObjs = new SObject[] {};
 		SObject newObj;
 
 		// Get one copy of the object
-		if (defaultClassName == null) {
-			newObj = createSObject(sObj);
-		} else {
-			newObj = createSObject(sObj, defaultClassName);
+		if (defaultClassName != null) {
+			newObj = createSObject(sObj, defaultClassName, autoSetRequiredFields);
+		} 
+		else {
+			newObj = createSObject(sObj, autoSetRequiredFields);
 		}
 
 		// Get the name field for the object
@@ -126,24 +95,6 @@ public class TestFactory {
 		for (Integer i = 0; i < numberOfObjects; i++) {
 			SObject clonedSObj = newObj.clone(false, true);
 			clonedSObj.put(nameField, (String)clonedSObj.get(nameField) + ' ' + i);
-			sObjs.add(clonedSObj);
-		}
-		return sObjs;
-	}
-
-	public static SObject[] createSObjectRequiredList(Sobject sObj, Integer numberOfObjects) {
-		SObject[] sObjs = new SObject[] {};
-
-		// Get the name field for the object
-		String nameField = nameFieldMap.get(String.valueOf(sObj.getSObjectType()));
-		if (nameField == null) {
-			nameField = 'Name';
-		}
-
-		for (Integer i = 0; i < numberOfObjects; i++) {
-			SObject clonedSObj = sObj.clone(false, true);
-			clonedSObj = createSObjectRequired(clonedSObj);
-			clonedSObj.put(nameField, (String)clonedSObj.get(nameField) + '' + i);
 			sObjs.add(clonedSObj);
 		}
 		return sObjs;
@@ -207,6 +158,46 @@ public class TestFactory {
 			return new Map<Schema.SObjectField, Object> {
 				Case.Subject => 'Test Case'
 			};
+		}
+	}
+
+	/**
+	 * The method automatically setups random values for required custom fields for the given object
+	 * But only the fields that were not already populated
+	 * As a first step, only the following types are supported: 'STRING', 'TEXTAREA', 'EMAIL', 'URL'
+	 * More to be supported in the future: base64, currency, Date, Datetime, Double, Integer, Multipicklist, Picklist, percent
+	 * @param  sObj                    sobject token
+	 * @return                         generic sobject for testing purposes, with custom required fields randomly populated
+	 */
+	public static void addRequiredFields(SObject sObj) {
+		Map<String, Object> map_populatedFields = sObj.getPopulatedFieldsAsMap();
+		if (requiredFields == null) {
+			requiredFields = getRequiredCustomFields(sObj);
+		}
+
+		for (Schema.DescribeFieldResult fieldDesc : requiredFields) {
+			Schema.SObjectField fieldToken = fieldDesc.getSObjectField();
+			String currentType = fieldDesc.getType().name().toUpperCase();
+
+			// Only generate a random valu when the field is not already populated
+			if (!map_populatedFields.containsKey(String.valueOf(fieldToken))) {
+				Object randomFieldVal;
+				// If current type is String
+				if (currentType == 'STRING' || currentType == 'TEXTAREA') {
+					Integer fieldLength = fieldDesc.getLength() > 4 ? 4 : fieldDesc.getLength();
+					randomFieldVal = getRandomStr(fieldLength);
+				}
+				// If current field type is email
+				else if (currentType == 'EMAIL') {
+					randomFieldVal = getRandomStr(4) + '@' + getRandomStr(4) + '.com';
+				}
+				// If current field type is URL
+				else if (currentType == 'URL') {
+					randomFieldVal = 'http://' + getRandomStr(4) + '.com';
+				}
+				// Finally, populate the record with the required fields
+				sObj.put(fieldToken, randomFieldVal);
+			}	
 		}
 	}
 

--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -1,7 +1,7 @@
 @isTest
 public class TestFactory {
 
-	// Cached metadata structure
+	// Cached metadata structures
 	public static Map<String, List<Schema.DescribeFieldResult>> requiredFieldsMap = new Map<String, List<Schema.DescribeFieldResult>>();
 	public static Map<String, Map<String, Schema.SObjectField>> sobjectToFieldsMap = new Map<String, Map<String, Schema.SObjectField>>();
 	public static Map<String, List<String>> uniqueFieldsMap = new Map<String, List<String>>();
@@ -206,8 +206,7 @@ public class TestFactory {
 	/**
 	 * The method automatically setups random values for required custom fields for the given sobject.
 	 * But only the fields that were not already populated get a random value.
-	 * For now, only the following types are supported: 'STRING', 'TEXTAREA', 'EMAIL', 'URL'
-	 * More to be supported in the future: base64, currency, Date, Datetime, Double, Integer, Multipicklist, Picklist, percent
+	 * For now, only the following types are supported: Base64, EncryptedString, Time, Reference (lookup and master-detail)
 	 * @param  sObj                    sobject token
 	 * @return                         generic sobject for testing purposes, with custom required fields randomly populated
 	 */
@@ -227,19 +226,37 @@ public class TestFactory {
 			// Only generate a random valu when the field is not already populated
 			if (!map_populatedFields.containsKey(String.valueOf(fieldToken))) {
 				Object randomFieldVal;
-				// If current type is String
 				if (currentType == 'STRING' || currentType == 'TEXTAREA') {
 					Integer fieldLength = fieldDesc.getLength() > 4 ? 4 : fieldDesc.getLength();
 					randomFieldVal = getRandomStr(fieldLength);
 				}
-				// If current field type is email
+				else if (currentType == 'CURRENCY' || currentType == 'DOUBLE' || currentType == 'INTEGER' || currentType == 'PERCENT') {
+					randomFieldVal = Math.mod(Math.abs(Crypto.getRandomInteger()), 100);
+				}
 				else if (currentType == 'EMAIL') {
 					randomFieldVal = getRandomStr(4) + '@' + getRandomStr(4) + '.com';
 				}
-				// If current field type is URL
 				else if (currentType == 'URL') {
 					randomFieldVal = 'http://' + getRandomStr(4) + '.com';
 				}
+				else if (currentType == 'DATE') {
+					Integer randomAdditionalMonths = Math.mod(Math.abs(Crypto.getRandomInteger()), 8);
+					randomFieldVal = Date.today().addMonths(randomAdditionalMonths);
+				}
+				else if (currentType == 'DATETIME') {
+					Integer randomAdditionalMonths = Math.mod(Math.abs(Crypto.getRandomInteger()), 8);
+					randomFieldVal = Datetime.now().addMonths(randomAdditionalMonths);
+				}
+				else if (currentType == 'PICKLIST') {
+					List<String> lst_picklistVals = getPicklistVals(objectName, fieldDesc.getName());
+					Integer randomIndex = Math.mod(Math.abs(Crypto.getRandomInteger()), lst_picklistVals.size());
+					randomFieldVal = lst_picklistVals.get(randomIndex);
+				}
+				else if (currentType == 'MULTIPICKLIST') {
+					List<String> lst_picklistVals = getPicklistVals(objectName, fieldDesc.getName());
+					randomFieldVal = String.join(lst_picklistVals, ';');
+				}
+
 				// Finally, populate the record with the required fields
 				sObj.put(fieldToken, randomFieldVal);
 			}	
@@ -263,7 +280,6 @@ public class TestFactory {
 
     public static List<Schema.DescribeFieldResult> getRequiredCustomFields(String objectName) {
 		List<Schema.DescribeFieldResult> lst_requiredFields = new List<Schema.DescribeFieldResult>();
-		
 		if (!sobjectToFieldsMap.containsKey(objectName)) {
 			sobjectToFieldsMap.put(objectName, Schema.getGlobalDescribe().get(objectName).getDescribe().fields.getMap());
 		}
@@ -283,7 +299,6 @@ public class TestFactory {
 
     public static List<String> getUniqueCustomFields(String objectName) {
 		List<String> lst_uniqueFields = new List<String>();
-
 		if (!sobjectToFieldsMap.containsKey(objectName)) {
 			sobjectToFieldsMap.put(objectName, Schema.getGlobalDescribe().get(objectName).getDescribe().fields.getMap());
 		}
@@ -298,5 +313,17 @@ public class TestFactory {
 		}
 		return lst_uniqueFields;	
     }
+
+    public static List<String> getPicklistVals(String objectName, String fieldName) {
+		List<String> lst_pickliststrs = new List<String>();
+		if (!sobjectToFieldsMap.containsKey(objectName)) {
+			sobjectToFieldsMap.put(objectName, Schema.getGlobalDescribe().get(objectName).getDescribe().fields.getMap());
+		}
+		List<Schema.PicklistEntry> lst_picklistVals = sobjectToFieldsMap.get(objectName).get(fieldName).getDescribe().getPicklistValues();
+   		for(Schema.PicklistEntry val : lst_picklistVals) {
+			lst_pickliststrs.add(val.getValue());
+  	 	}       
+   		return lst_pickliststrs;
+	}
 
 }

--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -1,6 +1,8 @@
 @isTest
 public class TestFactory {
 
+	public static List<Schema.DescribeFieldResult> requiredFields;
+
 	public static SObject createSObject(SObject sObj) {
 		// Check what type of object we are creating and add any defaults that are needed.
 		String objectName = String.valueOf(sObj.getSObjectType());
@@ -37,6 +39,49 @@ public class TestFactory {
 		if (doInsert) {
 			insert retObject;
 		}
+		return retObject;
+	}
+
+	 /**
+	 * The method automatically setups random values for required custom fields for the given object
+	 * But only if the user didn't input values or default value doesn't exist.
+	 * As a first step, only these types are supported: 'STRING', 'TEXTAREA', 'EMAIL', 'URL'
+	 * More to be supported in the future: base64, currency, Date, Datetime, Double, Integer, Multipicklist, Picklist, percent
+	 * @param  sObj                    sobject token
+	 * @return                         generic sobject for testing purposes, with custom required fields randomly populated
+	 */
+	public static SObject createSObjectRequired(SObject sObj) {
+		SObject retObject = createSObject(sObj);
+
+		Map<String, Object> map_populatedFields = retObject.getPopulatedFieldsAsMap();
+		if (requiredFields == null) {
+			requiredFields = getRequiredCustomFields(retObject);
+		}
+
+		for (Schema.DescribeFieldResult fieldDesc : requiredFields) {
+			Schema.SObjectField fieldToken = fieldDesc.getSObjectField();
+			String currentType = fieldDesc.getType().name().toUpperCase();
+
+			// If the required custom field is already populated, continue
+			if (!map_populatedFields.containsKey(String.valueOf(fieldToken))) {
+				Object randomFieldVal;
+				// If current type is String
+				if (currentType == 'STRING' || currentType == 'TEXTAREA') {
+					Integer fieldLength = fieldDesc.getLength() > 20 ? 20 : fieldDesc.getLength();
+					randomFieldVal = getRandomStr(fieldLength);
+				}
+				// If current type is email
+				else if (currentType == 'EMAIL') {
+					randomFieldVal = getRandomStr(10) + '@' + getRandomStr(7) + '.com';
+				}
+				else if (currentType == 'URL') {
+					randomFieldVal = 'http://' + getRandomStr(10) + '.com';
+				}
+				// Finally, populate the record with the required fields
+				retObject.put(fieldToken, randomFieldVal);
+			}	
+		}
+
 		return retObject;
 	}
 
@@ -81,6 +126,24 @@ public class TestFactory {
 		for (Integer i = 0; i < numberOfObjects; i++) {
 			SObject clonedSObj = newObj.clone(false, true);
 			clonedSObj.put(nameField, (String)clonedSObj.get(nameField) + ' ' + i);
+			sObjs.add(clonedSObj);
+		}
+		return sObjs;
+	}
+
+	public static SObject[] createSObjectRequiredList(Sobject sObj, Integer numberOfObjects) {
+		SObject[] sObjs = new SObject[] {};
+
+		// Get the name field for the object
+		String nameField = nameFieldMap.get(String.valueOf(sObj.getSObjectType()));
+		if (nameField == null) {
+			nameField = 'Name';
+		}
+
+		for (Integer i = 0; i < numberOfObjects; i++) {
+			SObject clonedSObj = sObj.clone(false, true);
+			clonedSObj = createSObjectRequired(clonedSObj);
+			clonedSObj.put(nameField, (String)clonedSObj.get(nameField) + '' + i);
 			sObjs.add(clonedSObj);
 		}
 		return sObjs;
@@ -146,4 +209,42 @@ public class TestFactory {
 			};
 		}
 	}
+
+	/**
+	 * Generate a random String given its size
+	 * @param  size: length of the String
+	 * @return     Random String
+	 */
+    public static String getRandomStr(Integer size) {
+        final String lst_range = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz';
+        String randomStr = '';
+        for(Integer i = 0; i < size; i++) {
+           Integer randomIndex = Math.mod(Math.abs(Crypto.getRandomInteger()), lst_range.length());
+           randomStr += lst_range.substring(randomIndex, randomIndex + 1);
+        }
+        return randomStr; 
+    }
+
+    /**
+     * Given a sobject, the method provides the list of required custom fields except formulas, auto-number
+     * and field with already a default value defined
+     * @param  sObj sobject token
+     * @return      List<Schema.DescribeFieldResult> of required custom fields
+     */
+    public static List<Schema.DescribeFieldResult> getRequiredCustomFields(SObject sObj) {
+    	String objectName = String.valueOf(sObj.getSObjectType());
+		List<Schema.DescribeFieldResult> lst_requiredFields = new List<Schema.DescribeFieldResult>();
+		List<Schema.SObjectField> lst_fields = Schema.getGlobalDescribe().get(objectName).getDescribe().fields.getMap().values();
+		
+		for(Schema.SObjectField field : lst_fields) { 
+			Schema.DescribeFieldResult fieldDesc = field.getDescribe();
+			if (!fieldDesc.isNillable() && !fieldDesc.isAutoNumber() && !fieldDesc.isCalculated() 
+				&& !fieldDesc.isDefaultedOnCreate() && fieldDesc.isCustom()) 
+			{
+				lst_requiredFields.add(fieldDesc);
+			}
+		}
+		return lst_requiredFields;	
+    }
+
 }

--- a/src/classes/TestFactory.cls
+++ b/src/classes/TestFactory.cls
@@ -4,7 +4,7 @@ public class TestFactory {
 	// Cached metadata structure
 	public static Map<String, List<Schema.DescribeFieldResult>> requiredFieldsMap = new Map<String, List<Schema.DescribeFieldResult>>();
 	public static Map<String, Map<String, Schema.SObjectField>> sobjectToFieldsMap = new Map<String, Map<String, Schema.SObjectField>>();
-	public static Map<String, List<String>> uniqueCustomFields = new Map<String, List<String>>();
+	public static Map<String, List<String>> uniqueFieldsMap = new Map<String, List<String>>();
 
 	public static SObject createSObject(SObject sObj, Boolean autoSetRequiredFields) {
 		// Check what type of object we are creating and add any defaults that are needed.
@@ -25,6 +25,15 @@ public class TestFactory {
 		}
 		insert retObject;
 		return retObject;
+	}
+
+	public static SObject insertSObject(SObject sObj, Boolean autoSetRequiredFields, User usr) {
+		if (usr != null) {
+			System.runAs(usr) {
+				return insertSObject(sObj, autoSetRequiredFields);
+			}
+		}
+		return insertSObject(sObj, autoSetRequiredFields);
 	}
 
 	public static SObject createSObject(SObject sObj, String defaultClassName, Boolean autoSetRequiredFields) {
@@ -51,6 +60,15 @@ public class TestFactory {
 		return retObject;
 	}
 
+	public static SObject insertSObject(SObject sObj, String defaultClassName, Boolean autoSetRequiredFields, User usr) {
+		if (usr != null) {
+			System.runAs(usr) {
+				return insertSObject(sObj, defaultClassName, autoSetRequiredFields);
+			}
+		}
+		return insertSObject(sObj, defaultClassName, autoSetRequiredFields);
+	}
+
 	public static SObject[] createSObjectList(Sobject sObj, Integer numberOfObjects, Boolean autoSetRequiredFields) {
 		return createSObjectList(sObj, numberOfObjects, (String)null, autoSetRequiredFields);
 	}
@@ -61,10 +79,28 @@ public class TestFactory {
 		return retList;
 	}
 
+	public static SObject[] insertSObjectList(SObject sObj, Integer numberOfObjects, Boolean autoSetRequiredFields, User usr) {
+		if (usr != null) {
+			System.runAs(usr) {
+				return insertSObjectList(sObj, numberOfObjects, autoSetRequiredFields);
+			}
+		}
+		return insertSObjectList(sObj, numberOfObjects, autoSetRequiredFields);
+	}
+
 	public static SObject[] insertSObjectList(SObject sObj, Integer numberOfObjects, String defaultClassName, Boolean autoSetRequiredFields) {
 		SObject[] retList = createSObjectList(sObj, numberOfObjects, defaultClassName, autoSetRequiredFields);
 		insert retList;
 		return retList;
+	}
+
+	public static SObject[] insertSObjectList(SObject sObj, Integer numberOfObjects, String defaultClassName, Boolean autoSetRequiredFields, User usr) {
+		if (usr != null) {
+			System.runAs(usr) {
+				return insertSObjectList(sObj, numberOfObjects, defaultClassName, autoSetRequiredFields);
+			}
+		}
+		return insertSObjectList(sObj, numberOfObjects, defaultClassName, autoSetRequiredFields);
 	}
 
 	public static SObject[] createSObjectList(Sobject sObj, Integer numberOfObjects, String defaultClassName, Boolean autoSetRequiredFields) {
@@ -80,8 +116,8 @@ public class TestFactory {
 			newObj = createSObject(sObj, autoSetRequiredFields);
 		}
 
-		if (uniqueCustomFields == null || !uniqueCustomFields.containsKey(objectName)) {
-			uniqueCustomFields.put(objectName, getUniqueCustomFields(objectName));
+		if (!uniqueFieldsMap.containsKey(objectName)) {
+			uniqueFieldsMap.put(objectName, getUniqueCustomFields(objectName));
 		}
 
 		List<String> lst_uniqueFields = new List<String>();
@@ -93,7 +129,7 @@ public class TestFactory {
 		lst_uniqueFields.add(nameField);
 
 		// Get other unique custom fields for the object
-		lst_uniqueFields.addAll(uniqueCustomFields.get(objectName));
+		lst_uniqueFields.addAll(uniqueFieldsMap.get(objectName));
 
 		// Clone the object the number of times requested. Increment the name field + unique fields so each record is unique
 		for (Integer i = 0; i < numberOfObjects; i++) {
@@ -179,7 +215,7 @@ public class TestFactory {
 		String objectName = String.valueOf(sObj.getSObjectType());
 		Map<String, Object> map_populatedFields = sObj.getPopulatedFieldsAsMap();
 
-		if (requiredFieldsMap == null || !requiredFieldsMap.containsKey(objectName)) {
+		if (!requiredFieldsMap.containsKey(objectName)) {
 			requiredFieldsMap.put(objectName, getRequiredCustomFields(objectName));
 		}
 


### PR DESCRIPTION
SObject factory that can be used in unit tests to create test data. This is a fork of dhoechst repo: https://github.com/dhoechst/Salesforce-Test-Factory. It keeps the same core functionality and exntends it.

Main features are:

    - Auto-generatation of test data for required and unique fields. Required fields automatically get populated with random values if you set the param autoSetRequiredFields to true. You don't have to worry about unique fields either, they are incremented in bulk scenarios.
    - RunAs(user) to test different scenarios for different users/profiles.
    - Differentiate insertion and creation methods. If the method name start with "create", then it only creates the record without inserting it into the database. If the method starts with "insert", the record is created and inserted in the database.
